### PR TITLE
Subtitles in post lists

### DIFF
--- a/_includes/page/posts_by_year.html
+++ b/_includes/page/posts_by_year.html
@@ -35,6 +35,10 @@ Remember to assign the `posts` variable before including this template:
                             <div>
                                 <span class="post-teaser__subtitle">$ [{{ post.ctf_categories | join: ', ' }}]</span>
                             </div>
+                        {% else if post.subtitle %}
+                            <div>
+                                <span class="post-teaser__subtitle">{{ post.subtitle}}</span>
+                            </div>
                         {% endif %}
                     </li>
                 {% endfor %}

--- a/_includes/page/posts_by_year.html
+++ b/_includes/page/posts_by_year.html
@@ -37,7 +37,7 @@ Remember to assign the `posts` variable before including this template:
                             </div>
                         {% else if post.subtitle %}
                             <div>
-                                <span class="post-teaser__subtitle">{{ post.subtitle}}</span>
+                                <span class="post-teaser__subtitle">{{ post.subtitle }}</span>
                             </div>
                         {% endif %}
                     </li>

--- a/_includes/page/posts_by_year.html
+++ b/_includes/page/posts_by_year.html
@@ -27,8 +27,15 @@ Remember to assign the `posts` variable before including this template:
                 </div>
                 {% for post in year.items %}
                     <li class="post-teaser">
-                        <span class="post-teaser__title"><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></span>
-                        <span class="post-teaser__date">{{ post.date | date: "%d %B %Y" }}</span>
+                        <div>
+                            <span class="post-teaser__title"><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></span>
+                            <span class="post-teaser__date">{{ post.date | date: "%d %B %Y" }}</span>
+                        </div>
+                        {% if post.ctf_categories %}
+                            <div>
+                                <span class="post-teaser__subtitle">$ [{{ post.ctf_categories | join: ', ' }}]</span>
+                            </div>
+                        {% endif %}
                     </li>
                 {% endfor %}
             {% endfor %}

--- a/_includes/post/title.html
+++ b/_includes/post/title.html
@@ -1,4 +1,6 @@
 <h1 class="page-title post-title">
     <div class="page-title__text post-title__text">{{ page.title }}</div>
+    {% comment %}
     <div class="page-title__subtitle post-title__subtitle">{{ page.subtitle }}</div>
+    {% endcomment %}
 </h1>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,11 +19,11 @@ layout: default
             </div>
         {%- endif -%}
 
-        {% if page.head_ctf_categories -%}
+        {% if page.ctf_categories -%}
             <p class="categories-index" id="categories-index">
                 <b>Categories index</b>
                 <br>
-                {%- for category in page.head_ctf_categories -%}
+                {%- for category in page.ctf_categories -%}
                     <a href="#{{ category | remove: '/' | downcase }}">{{ category | capitalize }}</a>{% unless forloop.last %} - {% endunless %}
                 {%- endfor -%}
             </p>

--- a/_posts/2019-04-02-TyumenCTF-Millennium.md
+++ b/_posts/2019-04-02-TyumenCTF-Millennium.md
@@ -5,7 +5,7 @@ title:  "TyumenCTF 2019"
 subtitle: "Millennium"
 date: 2019-04-02
 head_message: "These are our writeups for the challenges presented in this year's <a href=\"https://tyumenctf.ru/\">TyumenCTF</a>."
-head_ctf_categories:
+ctf_categories:
   - pwn
   - joy
   - misc

--- a/_posts/2019-04-08-SwampCTF.md
+++ b/_posts/2019-04-08-SwampCTF.md
@@ -4,7 +4,7 @@ category: writeups
 title:  "SwampCTF 2019"
 date: 2019-04-08
 head_message: "These are our writeups for the challenges presented in this year's <a href=\"https://swampctf.com/\">SwampCTF</a>."
-head_ctf_categories:
+ctf_categories:
   - misc
   - smart
   - web

--- a/_posts/2019-04-14-PlaidCTF.md
+++ b/_posts/2019-04-14-PlaidCTF.md
@@ -4,7 +4,7 @@ category: writeups
 title:  "PlaidCTF 2019"
 date: 2019-04-14
 head_message: "These are our writeups for the challenges presented in this year's <a href=\"https://plaidctf.com/\">PlaidCTF</a>."
-head_ctf_categories:
+ctf_categories:
   - misc
 ---
 

--- a/_posts/2019-04-20-AngstromCTF.md
+++ b/_posts/2019-04-20-AngstromCTF.md
@@ -4,7 +4,7 @@ category: writeups
 title:  "AngstromCTF 2019"
 date: 2019-04-20
 head_message: "These are our writeups for the challenges presented in this year's <a href=\"https://angstromctf.com/\">AngstromCTF</a>."
-head_ctf_categories:
+ctf_categories:
   - misc
   - rev
   - web

--- a/_posts/2019-05-10-TSGCTF.md
+++ b/_posts/2019-05-10-TSGCTF.md
@@ -4,7 +4,7 @@ category: writeups
 title:  "TSG CTF 2019"
 date: 2019-05-10
 head_message: "These are our writeups for the challenges presented in this year's <a href=\"https://ctf.tsg.ne.jp/\">TSG CTF</a>."
-head_ctf_categories:
+ctf_categories:
   - forensics
 ---
 

--- a/_posts/2020-03-20-TamuCTF.md
+++ b/_posts/2020-03-20-TamuCTF.md
@@ -3,7 +3,7 @@ layout: post
 category: writeups
 title:  "TAMUctf 2020"
 date: 2020-03-20
-head_ctf_categories:
+ctf_categories:
   - web
   - misc
   - rev

--- a/_posts/2020-03-29-VolgaCTF-Qualifiers.md
+++ b/_posts/2020-03-29-VolgaCTF-Qualifiers.md
@@ -4,7 +4,7 @@ category: writeups
 title: "VolgaCTF 2020"
 subtitle: "Qualifiers"
 date: 2020-03-29
-head_ctf_categories:
+ctf_categories:
   - crypto
   - forensics
 ---

--- a/_posts/2020-05-29-TJCTF.md
+++ b/_posts/2020-05-29-TJCTF.md
@@ -3,7 +3,7 @@ layout: post
 category: writeups
 title: "TJCTF 2020"
 date: 2020-05-29
-head_ctf_categories:
+ctf_categories:
   - web
 ---
 

--- a/_posts/2020-10-05-Bo1lersCTF.md
+++ b/_posts/2020-10-05-Bo1lersCTF.md
@@ -4,7 +4,7 @@ category: writeups
 title: "Bo1lers bootcamp CTF 2020"
 date: 2020-10-05
 head_message: "These are our writeups for the challenges presented in this year's <a href=\"https://play.ctf.b01lers.com/home\">Bo1lers bootcamp CTF 2020</a>."
-head_ctf_categories:
+ctf_categories:
   - web
   - crypto
 ---

--- a/_posts/2021-03-15-UTCTF.md
+++ b/_posts/2021-03-15-UTCTF.md
@@ -4,7 +4,7 @@ category: writeups
 title: "UTCTF 2021"
 date: 2021-03-15
 head_message: "Welcoming our new team members for 2021! This was the first CTF for most of them."
-head_ctf_categories:
+ctf_categories:
   - crypto
   - web
   - networking

--- a/_posts/2021-03-21-LineCTF.md
+++ b/_posts/2021-03-21-LineCTF.md
@@ -3,7 +3,7 @@ layout: post
 category: writeups
 title: "LineCTF 2021"
 date: 2021-03-21
-head_ctf_categories:
+ctf_categories:
   - crypto
   - web
 ---

--- a/_posts/2021-03-28-VolgaCTF-Qualifiers.md
+++ b/_posts/2021-03-28-VolgaCTF-Qualifiers.md
@@ -4,7 +4,7 @@ category: writeups
 title: "VolgaCTF 2021"
 subtitle: "Qualifiers"
 date: 2021-03-28
-head_ctf_categories:
+ctf_categories:
   - web
 ---
 

--- a/_posts/2021-04-08-AngstromCTF.md
+++ b/_posts/2021-04-08-AngstromCTF.md
@@ -3,7 +3,7 @@ layout: post
 category: writeups
 title: "ångstromCTF 2021"
 date: 2021-04-08
-head_ctf_categories:
+ctf_categories:
   - web
 ---
 

--- a/_posts/2021-06-19-DanteCTF.md
+++ b/_posts/2021-06-19-DanteCTF.md
@@ -4,7 +4,7 @@ category: writeups
 title: "DanteCTF 2021"
 date: 2021-06-19
 head_message: "Writeups per la prima edizione della DanteCTF"
-head_ctf_categories:
+ctf_categories:
   - web
   - crypto
   - misc

--- a/_posts/2021-06-29-How-we-hosted-DanteCTF-2021.md
+++ b/_posts/2021-06-29-How-we-hosted-DanteCTF-2021.md
@@ -2,8 +2,9 @@
 layout: post
 category: articles
 title: "How we hosted DanteCTF 2021"
+subtitle: "A brief tour of the infrastructure that supported the first edition of DanteCTF"
 date: 2021-06-29
-head_message: "A brief tour of the infrastructure that supported the first edition of DanteCTF"
+head_message: "A brief tour of the infrastructure that supported the first edition of DanteCTF."
 author: synack
 ---
 

--- a/_posts/2022-03-07-UMDCTF.md
+++ b/_posts/2022-03-07-UMDCTF.md
@@ -4,7 +4,7 @@ category: writeups
 title: "UMDCTF 2022"
 date: 2022-03-07
 head_message: "These are our writeups for the challenges presented in this year's <a href=\"https://umdctf.io\">UMDCTF</a>."
-head_ctf_categories:
+ctf_categories:
   - crypto
   - forensics
   - hw/rf

--- a/_sass/_default.scss
+++ b/_sass/_default.scss
@@ -266,6 +266,11 @@ strong {
                 vertical-align: middle;
                 color: $intermediate;
             }
+
+            .post-teaser__subtitle {
+                font-size: 18px;
+                color: $intermediate;
+            }
         }
     }
 


### PR DESCRIPTION
The frontmatter key `head_ctf_categories` has been generalized to `ctf_categories` and will be shown as a stylized subtitle in the main posts list.

The unused `subtitle` key has been disabled in the post itself, superseded by the less cluttering `head_message`. If set, `subtitle` will now only be shown in the post list in place of `ctf_categories`.

---

Order of precedence of subtitle keys:
1. `ctf_categories`
2. `subtitle`
3. _None_
